### PR TITLE
Fixes for albatradis compatibility

### DIFF
--- a/quatradis/isp_analyse.py
+++ b/quatradis/isp_analyse.py
@@ -54,6 +54,7 @@ def create_output_filenames(files, joined_output=False, output_dir="", output_su
     out_files = []
     for f in files:
         file_base = os.path.basename(os.path.basename(f))
+        file_base = file_base.split(sep='.')[0]
         out_files.append(os.path.join(output_dir, file_base + "." + output_suffix))
 
     return out_files
@@ -94,7 +95,7 @@ def get_gene_name(feature):
     else:
         gene_name = get_feature_id(feature)
     # Replace any non-word character
-    gene_name = "".join([c for c in gene_name if c.isalnum()])
+    gene_name = "".join([c for c in gene_name if c.isalnum() or c == '_'])
     return gene_name
 
 
@@ -144,7 +145,7 @@ def relevant_feature(feature, cds_coordinates):
 def count_inserts(insert_sites, read_start, read_end):
     count = 0
     inserts = 0
-    for j in range(read_start, read_end + 1):
+    for j in range(read_start, read_end):
         count += insert_sites[j]
         if insert_sites[j] > 0:
             inserts += 1

--- a/tests/isp_analyse_test.py
+++ b/tests/isp_analyse_test.py
@@ -31,8 +31,8 @@ class AnalyseInsertSitesTest(unittest.TestCase):
         isp_analyse.analyse_insert_sites(embl_file="data/isp_analyse/reference_BW25113_short.embl",
                                                 plot_files=["data/isp_analyse/controlLBrep1.insert_site_plot_short.gz",
                                                             "data/isp_analyse/025mgLTricRep1.insert_site_plot_short.gz"])
-        self.assertTrue(os.path.exists("controlLBrep1.insert_site_plot_short.gz.tradis_gene_insert_sites.csv"))
-        self.assertTrue(os.path.exists("025mgLTricRep1.insert_site_plot_short.gz.tradis_gene_insert_sites.csv"))
+        self.assertTrue(os.path.exists("controlLBrep1.tradis_gene_insert_sites.csv"))
+        self.assertTrue(os.path.exists("025mgLTricRep1.tradis_gene_insert_sites.csv"))
         os.system("rm *.tradis_gene_insert_sites.csv")
 
     def test_analyse_insert_sites_joined(self):


### PR DESCRIPTION
Fixing name of analysis output files for consumption by albatradis.

Fixing mistake when creating gene names during insertion site analysis..  Shouldn't have ignored underscores in the name.