### PR TITLE
fix(regulated_report): correct use of annotations

### DIFF
--- a/quatradis/comparison/cli.py
+++ b/quatradis/comparison/cli.py
@@ -271,7 +271,7 @@ def add_genereport_options(parser):
         "--output_dir", "-o", help="Output filename prefix", type=str, default="."
     )
     parser.add_argument(
-        "--annotations", "-a", help="EMBL file used for annotations", type=str
+        "--use_annotations", "-a", help="EMBL file is a real EMBL file with annotations (not a set of windows)", action="store_true", default=False
     )
 
 
@@ -284,7 +284,7 @@ def gene_report(args):
         window_size=args.window_size,
         embl_file=args.embl,
         output_dir=args.output_dir,
-        annotation_file=args.annotations,
+        use_annotations=args.use_annotations,
     )
 
 

--- a/quatradis/comparison/gene_stats.py
+++ b/quatradis/comparison/gene_stats.py
@@ -8,34 +8,29 @@ from quatradis.gene.gene import Gene
 from quatradis.util.file_handle_helpers import ensure_output_dir_exists
 
 
-def gene_statistics(combined_plotfile, forward_plotfile, reverse_plotfile, combined_scorefile, window_size, embl_file, output_dir="output", annotation_file=None):
+def gene_statistics(combined_plotfile, forward_plotfile, reverse_plotfile, combined_scorefile, window_size, embl_file, output_dir="output", use_annotations=False):
 
     ensure_output_dir_exists(output_dir)
 
-    use_annotation = True if annotation_file else False
-
     b = BlockIdentifier(combined_plotfile, forward_plotfile, reverse_plotfile, combined_scorefile, window_size)
     blocks = b.block_generator()
-    ant_file = embl_file
-    if use_annotation:
-        ant_file = annotation_file
 
-    genes = GeneAnnotator(ant_file, blocks).annotate_genes()
+    genes = GeneAnnotator(embl_file, blocks).annotate_genes()
     intergenic_blocks = [block for block in blocks if block.intergenic]
 
-    if not use_annotation:
-        all_genes = merge_windows(genes)
-    else:
+    if use_annotations:
         all_genes = []
         for g in genes:
             all_genes.append(g)
+    else:
+        all_genes = merge_windows(genes)
 
     report_file = os.path.join(output_dir, "gene_report.tsv")
 
     if len(all_genes) == 0 and len(intergenic_blocks) == 0:
         print("No significant genes found for chosen parameters.\n")
 
-    write_gene_report(all_genes, intergenic_blocks, report_file, use_annotation)
+    write_gene_report(all_genes, intergenic_blocks, report_file, use_annotations)
     write_regulated_gene_report(all_genes, os.path.join(output_dir, "regulated_gene_report.tsv"))
 
     # if self.verbose:

--- a/quatradis/pipelines/compare.smk
+++ b/quatradis/pipelines/compare.smk
@@ -64,15 +64,15 @@ rule finish:
 rule prepare_embl:
     input:
         plot=config["control_files"][0],
-        embl=config["annotations"]
     output: os.path.join(config["output_dir"], "prepared.embl")
     message: "Preparing embl annotations file"
     params:
         minimum_threshold="--minimum_threshold=" + config["minimum_threshold"] if config["minimum_threshold"] else "",
         window_size="--window_size=" + config["window_size"] if config["window_size"] else "",
         window_interval="--window_interval=" + config["window_interval"] if config["window_interval"] else "",
-        prime_feature_size="--prime_feature_size=" + config["prime_feature_size"] if config["prime_feature_size"] else ""
-    shell: "tradis compare prepare_embl --output={output} {params.minimum_threshold} {params.window_size} {params.window_interval} {params.prime_feature_size} --emblfile {input.embl} {input.plot}"
+        prime_feature_size="--prime_feature_size=" + config["prime_feature_size"] if config["prime_feature_size"] else "",
+        embl="--emblfile=" + config["annotations"] if "annotations" in config else ""
+    shell: "tradis compare prepare_embl --output={output} {params.minimum_threshold} {params.window_size} {params.window_interval} {params.prime_feature_size} {params.embl} {input.plot}"
 
 rule normalise:
     input:
@@ -175,7 +175,7 @@ rule gene_stats:
         input_dir=os.path.join(config["output_dir"], "comparison"),
         output_dir="--output_dir=" + config["output_dir"],
         window_size="--window_size=" + config["window_size"],
-        annotations="--annotations=" + config["annotations"] if not config["annotations"]=="None" else "",
+        annotations="--use_annotations" if "annotations" in config else "",
         scores="--scores=" + os.path.join(config["output_dir"],"comparison","combined","combined.pqvals.plot")
     message: "Creating gene report"
     shell: "tradis compare gene_report --combined={input.combined} --forward={input.forward} --reverse={input.rev} {params.scores} {params.window_size} {params.output_dir} {params.annotations} {input.embl}"

--- a/quatradis/pipelines/pipeline.py
+++ b/quatradis/pipelines/pipeline.py
@@ -180,9 +180,8 @@ def compare_options(parser):
     parser.add_argument(
         "--annotations",
         "-a",
-        help="If provided genes in this EMBL annotations file will expanded based on data in the plotfile.",
+        help="If provided genes in this EMBL annotations file will expanded based on data in the plotfile.  Otherwise create a new EMBL from the plotfiles.",
         type=str,
-        default=None,
     )
     parser.add_argument(
         "--minimum_threshold",
@@ -291,7 +290,8 @@ def compare_pipeline(args):
         ofql.write(
             create_yaml_option("normalise", not args.disable_normalisation, bool=True)
         )
-        ofql.write(create_yaml_option("annotations", args.annotations))
+        if args.annotations:
+            ofql.write(create_yaml_option("annotations", args.annotations))
         ofql.write(create_yaml_option("minimum_threshold", args.minimum_threshold))
         ofql.write(create_yaml_option("prime_feature_size", args.prime_feature_size))
         ofql.write(create_yaml_option("window_interval", args.window_interval))


### PR DESCRIPTION
We had a bug where by the compare pipeline wouldn't function without provided EMBL annotations file.  This prevented use of automatically generated windows being used.  We also fix the code path in the gene statistics function so that we can use the appropriate logic depending on if the EMBL file is one with actual padded annotations or one with just the windows.